### PR TITLE
Try to make some sense of the string conversion operators.

### DIFF
--- a/timxmlrpc.h
+++ b/timxmlrpc.h
@@ -178,30 +178,15 @@ public:
 	bool operator==(XmlRpcValue const& other) const;
 	bool operator!=(XmlRpcValue const& other) const { return !(*this == other); }
 
-	// This is an alternative to operator std::string() that Aigner claims is needed for VS13
 	std::string GetStdString()	{
 								if (_type == TypeInt) {
-									char tmp[80];
-									_itoa_s(u.asInt, tmp, 10); // itoa(u.asInt, tmp, 10);
-									return (std::string)tmp;
+									char tmp[16];
+									_itoa_s(u.asInt, tmp, 10);
+									return tmp;
 								}
 								assertTypeOrInvalid(TypeString);
-								return std::string(u.asString);
+								return u.asString;
 							}
-
-#if defined(_MSC_VER) && (_MSC_VER > 1700)
-	operator const std::string& () { 
-								if (_type == TypeInt) {
-									char tmp[80];
-									_itoa_s(u.asInt, tmp, 10); // itoa(u.asInt, tmp, 10);
-									return std::move(std::string(tmp));
-								}
-								assertTypeOrInvalid(TypeString);
-								return std::move(std::string(u.asString));
-							}
-#else
-	operator std::string () { return GetStdString(); } 
-#endif
 
 	// There are some basic type conversions here. This might mean that your
 	// program parses stuff that strictly speaking it should report as a type error.
@@ -226,9 +211,6 @@ public:
 									return u.asInt;
 								assertTypeOrInvalid(TypeDouble);
 								return 0;
-							}
-	operator std::string&()	{ 
-								return GetStdString();
 							}
 
 	operator const char*()	{ assertTypeOrInvalid(TypeString); return u.asString; }


### PR DESCRIPTION
I'm opening this PR so that we can discuss this as I cannot really understand what was intended here. Don't merge it as is since I'm not satisfied with my changes yet.

The current code does not really seem to make sense. Returning a const reference on a temporary object is weird and returning a non const reference is even weirder (as in almost certainly wrong and not even supported by the standard). I'm also not sure that your use of `move` is correct. As far as I can tell it doesn't do anything harmful but most likely it won't do anything at all.

Since the conversion operator can create an entirely new string if the object is in fact an int, I would just keep a conversion operator that returns a `string`.
